### PR TITLE
Changed unsigned long types to uint32_t to fix ESP32 ultoa() bug

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -41,7 +41,7 @@ NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset) {
   this->_poolServerName = poolServerName;
 }
 
-NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset, unsigned long updateInterval) {
+NTPClient::NTPClient(UDP& udp, const char* poolServerName, int timeOffset, uint32_t updateInterval) {
   this->_udp            = &udp;
   this->_timeOffset     = timeOffset;
   this->_poolServerName = poolServerName;
@@ -113,11 +113,11 @@ bool NTPClient::forceUpdate() {
 
   this->_lastUpdate = millis() - (10 * (timeout + 1)); // Account for delay in reading the time
 
-  unsigned long highWord = word(this->_packetBuffer[40], this->_packetBuffer[41]);
-  unsigned long lowWord = word(this->_packetBuffer[42], this->_packetBuffer[43]);
+  uint32_t highWord = word(this->_packetBuffer[40], this->_packetBuffer[41]);
+  uint32_t lowWord = word(this->_packetBuffer[42], this->_packetBuffer[43]);
   // combine the four bytes (two words) into a long integer
   // this is NTP time (seconds since Jan 1 1900):
-  unsigned long secsSince1900 = highWord << 16 | lowWord;
+  uint32_t secsSince1900 = highWord << 16 | lowWord;
 
   this->_currentEpoc = secsSince1900 - SEVENZYYEARS;
 
@@ -133,7 +133,7 @@ bool NTPClient::update() {
   return true;
 }
 
-unsigned long NTPClient::getEpochTime() {
+uint32_t NTPClient::getEpochTime() {
   return this->_timeOffset + // User offset
          this->_currentEpoc + // Epoc returned by the NTP server
          ((millis() - this->_lastUpdate) / 1000); // Time since last update
@@ -152,15 +152,15 @@ int NTPClient::getSeconds() {
   return (this->getEpochTime() % 60);
 }
 
-String NTPClient::getFormattedTime(unsigned long secs) {
-  unsigned long rawTime = secs ? secs : this->getEpochTime();
-  unsigned long hours = (rawTime % 86400L) / 3600;
+String NTPClient::getFormattedTime(uint32_t secs) {
+  uint32_t rawTime = secs ? secs : this->getEpochTime();
+  int hours = (rawTime % 86400L) / 3600;
   String hoursStr = hours < 10 ? "0" + String(hours) : String(hours);
 
-  unsigned long minutes = (rawTime % 3600) / 60;
+  int minutes = (rawTime % 3600) / 60;
   String minuteStr = minutes < 10 ? "0" + String(minutes) : String(minutes);
 
-  unsigned long seconds = rawTime % 60;
+  int seconds = rawTime % 60;
   String secondStr = seconds < 10 ? "0" + String(seconds) : String(seconds);
 
   return hoursStr + ":" + minuteStr + ":" + secondStr;
@@ -168,9 +168,9 @@ String NTPClient::getFormattedTime(unsigned long secs) {
 
 // Based on https://github.com/PaulStoffregen/Time/blob/master/Time.cpp
 // currently assumes UTC timezone, instead of using this->_timeOffset
-String NTPClient::getFormattedDate(unsigned long secs) {
-  unsigned long rawTime = (secs ? secs : this->getEpochTime()) / 86400L;  // in days
-  unsigned long days = 0, year = 1970;
+String NTPClient::getFormattedDate(uint32_t secs) {
+  uint32_t rawTime = (secs ? secs : this->getEpochTime()) / 86400L;  // in days
+  int days = 0, year = 1970;
   uint8_t month;
   static const uint8_t monthDays[]={31,28,31,30,31,30,31,31,30,31,30,31};
 
@@ -203,7 +203,7 @@ void NTPClient::setTimeOffset(int timeOffset) {
   this->_timeOffset     = timeOffset;
 }
 
-void NTPClient::setUpdateInterval(unsigned long updateInterval) {
+void NTPClient::setUpdateInterval(uint32_t updateInterval) {
   this->_updateInterval = updateInterval;
 }
 
@@ -229,6 +229,6 @@ void NTPClient::sendNTPPacket() {
   this->_udp->endPacket();
 }
 
-void NTPClient::setEpochTime(unsigned long secs) {
+void NTPClient::setEpochTime(uint32_t secs) {
   this->_currentEpoc = secs;
 }

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -19,10 +19,10 @@ class NTPClient {
     int           _port           = NTP_DEFAULT_LOCAL_PORT;
     int           _timeOffset     = 0;
 
-    unsigned long _updateInterval = 60000;  // In ms
+    uint32_t      _updateInterval = 60000;  // In ms
 
-    unsigned long _currentEpoc    = 0;      // In s
-    unsigned long _lastUpdate     = 0;      // In ms
+    uint32_t      _currentEpoc    = 0;      // In s
+    uint32_t      _lastUpdate     = 0;      // In ms
 
     byte          _packetBuffer[NTP_PACKET_SIZE];
 
@@ -34,7 +34,7 @@ class NTPClient {
     NTPClient(UDP& udp, int timeOffset);
     NTPClient(UDP& udp, const char* poolServerName);
     NTPClient(UDP& udp, const char* poolServerName, int timeOffset);
-    NTPClient(UDP& udp, const char* poolServerName, int timeOffset, unsigned long updateInterval);
+    NTPClient(UDP& udp, const char* poolServerName, int timeOffset, uint32_t updateInterval);
 
     /**
      * Starts the underlying UDP client with the default local port
@@ -75,23 +75,23 @@ class NTPClient {
      * Set the update interval to another frequency. E.g. useful when the
      * timeOffset should not be set in the constructor
      */
-    void setUpdateInterval(unsigned long updateInterval);
+    void setUpdateInterval(uint32_t updateInterval);
 
     /**
     * @return secs argument (or 0 for current time) formatted like `hh:mm:ss`
     */
-    String getFormattedTime(unsigned long secs = 0);
+    String getFormattedTime(uint32_t secs = 0);
 
     /**
      * @return time in seconds since Jan. 1, 1970
      */
-    unsigned long getEpochTime();
+    uint32_t getEpochTime();
   
     /**
     * @return secs argument (or 0 for current date) formatted to ISO 8601
     * like `2004-02-12T15:19:21+00:00`
     */
-    String getFormattedDate(unsigned long secs = 0);
+    String getFormattedDate(uint32_t secs = 0);
 
     /**
      * Stops the underlying UDP client
@@ -101,5 +101,5 @@ class NTPClient {
     /**
     * Replace the NTP-fetched time with seconds since Jan. 1, 1970
     */
-    void setEpochTime(unsigned long secs);
+    void setEpochTime(uint32_t secs);
 };


### PR DESCRIPTION
A bug in Arduino-ESP32 core v2.0.0-rc1 (possibly others too) exists where ltoa() and ultoa() produce results with reversed strings.
For example the unsigned long 12345L will be converted to the string "54321". This bug propagates to the String constructor for unsigned long, which relies on ultoa(). Therefore, NTPClient.getFormattedTime() and NTPClient.getFormattedDate() produces invalid results on ESP32 using this core version (and possibly othes too), which is the current version for the ESP32-S2 variant.

Changing the types from unsigned long (which is probably 64 bit wide on ESP32) to uint32_t prevents this from happening, while the types are still wide enough to hold the 32 unsigned numbers.